### PR TITLE
fix getName() in NRA_B19 and NRA_B38 returning wrong target type

### DIFF
--- a/Software/C#/freETarget/targets/NRA_B19.cs
+++ b/Software/C#/freETarget/targets/NRA_B19.cs
@@ -55,7 +55,7 @@ namespace freETarget.targets {
             return ring10 / 2m + pelletCaliber / 2m;
         }
         public override string getName() {
-            return typeof(Pistol50m).FullName;
+            return typeof(NRA_B19).FullName;
         }
 
         public override decimal getOutterRing() {

--- a/Software/C#/freETarget/targets/NRA_B38.cs
+++ b/Software/C#/freETarget/targets/NRA_B38.cs
@@ -51,7 +51,7 @@ namespace freETarget.targets {
             return ring10 / 2m + pelletCaliber / 2m;
         }
         public override string getName() {
-            return typeof(Pistol25mRF).FullName;
+            return typeof(NRA_B38).FullName;
         }
 
         public override decimal getOutterRing() {


### PR DESCRIPTION
## Summary
- `NRA_B19.getName()` incorrectly returns `typeof(Pistol50m).FullName` instead of `typeof(NRA_B19).FullName`
- `NRA_B38.getName()` incorrectly returns `typeof(Pistol25mRF).FullName` instead of `typeof(NRA_B38).FullName`
- These appear to be copy-paste errors from when the classes were derived from `Pistol50m` and `Pistol25mRF`. The wrong type name causes incorrect target identification when saving/loading events.